### PR TITLE
feat: design system overhaul with Weekbook brand identity

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,68 @@
 @import "tailwindcss";
+
+@theme {
+  /* Color palette */
+  --color-cream-50: #fdfcf9;
+  --color-cream-100: #faf8f3;
+  --color-cream-200: #f5f0e8;
+  --color-cream-300: #ede4d4;
+  --color-cream-400: #d9cbb4;
+
+  --color-ink-50: #f5f5f5;
+  --color-ink-100: #ebebeb;
+  --color-ink-200: #d4d4d4;
+  --color-ink-300: #b8b8b8;
+  --color-ink-400: #909090;
+  --color-ink-500: #6b6b6b;
+  --color-ink-600: #404040;
+  --color-ink-700: #2a2a2a;
+  --color-ink-800: #1a1a1a;
+  --color-ink-900: #0f0f0f;
+
+  --color-amber: #d4a853;
+  --color-amber-light: #e8c97a;
+  --color-amber-dark: #b8892e;
+  --color-amber-muted: #f5e9cc;
+
+  /* Typography */
+  --font-sans: Inter, system-ui, -apple-system, sans-serif;
+  --font-display: Fraunces, Georgia, serif;
+
+  /* Animations */
+  --animate-fade-in: fadeIn 0.5s ease-out forwards;
+  --animate-slide-up: slideUp 0.5s ease-out forwards;
+  --animate-pulse-once: pulseOnce 0.6s ease-out forwards;
+
+  /* Shadows */
+  --shadow-warm: 0 1px 3px rgba(15, 15, 15, 0.06), 0 4px 12px rgba(15, 15, 15, 0.04);
+  --shadow-warm-lg: 0 4px 20px rgba(15, 15, 15, 0.08), 0 1px 4px rgba(15, 15, 15, 0.05);
+  --shadow-amber: 0 0 0 3px rgba(212, 168, 83, 0.25);
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulseOnce {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+  100% { transform: scale(1); }
+}
+
+/* Base */
+@layer base {
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  ::selection {
+    background-color: rgba(212, 168, 83, 0.25);
+  }
+}

--- a/app/javascript/controllers/fade_in_controller.js
+++ b/app/javascript/controllers/fade_in_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    if (!("IntersectionObserver" in window)) {
+      this.element.classList.remove("opacity-0")
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("animate-fade-in")
+            entry.target.classList.remove("opacity-0")
+            observer.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.08 }
+    )
+
+    observer.observe(this.element)
+  }
+}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,72 +1,91 @@
-<div class="mx-auto max-w-md">
+<div class="flex min-h-[70vh] items-center justify-center">
+  <div class="w-full max-w-sm animate-slide-up">
 
-  <h1 class="text-2xl font-semibold mb-6">
-    Create your account
-  </h1>
-
-  <div class="rounded-lg border bg-white p-6 shadow-sm">
-
-<div class="mb-6 space-y-3">
-  <%= button_to user_google_oauth2_omniauth_authorize_path,
-      method: :post,
-      class: "flex w-full items-center justify-center gap-3 rounded-md bg-black px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-zinc-800 cursor-pointer hover:-translate-y-0.5 active:translate-y-0" do %>
-    <span aria-hidden="true">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 fill-white">
-        <path d="M21.8 12.23c0-.68-.06-1.33-.17-1.96H12v3.71h5.5a4.7 4.7 0 0 1-2.04 3.08v2.56h3.3c1.94-1.79 3.04-4.42 3.04-7.39Z"/>
-        <path d="M12 22c2.75 0 5.06-.91 6.75-2.47l-3.3-2.56c-.91.61-2.08.97-3.45.97-2.65 0-4.89-1.79-5.69-4.2H2.9v2.64A10 10 0 0 0 12 22Z"/>
-        <path d="M6.31 13.74A5.98 5.98 0 0 1 6 12c0-.6.11-1.18.31-1.74V7.62H2.9A10 10 0 0 0 2 12c0 1.61.38 3.13 1.05 4.38l3.26-2.64Z"/>
-        <path d="M12 5.98c1.49 0 2.82.51 3.87 1.5l2.9-2.9C17.05 2.98 14.75 2 12 2A10 10 0 0 0 2.9 7.62l3.41 2.64c.8-2.41 3.04-4.28 5.69-4.28Z"/>
-      </svg>
-    </span>
-    <span>Continue with Google</span>
-  <% end %>
-
-  <%= button_to user_github_omniauth_authorize_path,
-      method: :post,
-      class: "flex w-full items-center justify-center gap-3 rounded-md bg-black px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-zinc-800 cursor-pointer hover:-translate-y-0.5 active:translate-y-0" do %>
-    <span aria-hidden="true">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 fill-white">
-        <path d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.41-4.04-1.41-.55-1.38-1.33-1.74-1.33-1.74-1.09-.74.08-.72.08-.72 1.2.09 1.84 1.24 1.84 1.24 1.08 1.84 2.82 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.48-1.33-5.48-5.92 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.4 11.4 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.67 1.66.25 2.88.13 3.18.77.84 1.23 1.91 1.23 3.22 0 4.6-2.82 5.61-5.5 5.91.43.38.82 1.1.82 2.22v3.29c0 .32.21.7.83.58A12 12 0 0 0 12 .5Z"/>
-      </svg>
-    </span>
-    <span>Continue with GitHub</span>
-  <% end %>
-</div>
-
-    <%= form_for(resource,
-        as: resource_name,
-        url: registration_path(resource_name)) do |f| %>
-
-      <div class="space-y-4">
-
-        <div>
-          <%= f.label :email, class: "block text-sm font-medium" %>
-          <%= f.email_field :email,
-              class: "mt-1 w-full rounded-md border px-3 py-2" %>
-        </div>
-
-        <div>
-          <%= f.label :password, class: "block text-sm font-medium" %>
-          <%= f.password_field :password,
-              class: "mt-1 w-full rounded-md border px-3 py-2" %>
-        </div>
-
-        <div>
-          <%= f.label :password_confirmation,
-              class: "block text-sm font-medium" %>
-          <%= f.password_field :password_confirmation,
-              class: "mt-1 w-full rounded-md border px-3 py-2" %>
-        </div>
-
-        <div>
-          <%= f.submit "Create account",
-              class: "w-full rounded-md bg-black px-4 py-2 text-white" %>
-        </div>
-
+    <div class="mb-8 text-center">
+      <div class="mb-3 flex items-center justify-center gap-2">
+        <span class="h-2.5 w-2.5 rounded-full bg-amber"></span>
+        <span class="font-display text-2xl font-light text-ink-900">Weekbook</span>
       </div>
+      <h1 class="font-display text-3xl font-light text-ink-900">Start your story</h1>
+      <p class="mt-1 text-sm text-ink-500">Your week, turned into something worth keeping.</p>
+    </div>
 
-    <% end %>
+    <div class="rounded-xl border border-cream-300 bg-white p-6 shadow-warm">
+
+      <% oauth_available = ENV['GOOGLE_CLIENT_ID'].present? || ENV['GITHUB_CLIENT_ID'].present? %>
+
+      <% if oauth_available %>
+        <div class="space-y-2.5">
+          <% if ENV['GOOGLE_CLIENT_ID'].present? %>
+            <%= button_to user_google_oauth2_omniauth_authorize_path,
+                method: :post,
+                class: "flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-cream-300 bg-white px-4 py-2.5 text-sm font-medium text-ink-800 transition-all duration-150 hover:bg-cream-100 hover:-translate-y-px active:translate-y-0" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4">
+                <path fill="#4285F4" d="M21.8 12.23c0-.68-.06-1.33-.17-1.96H12v3.71h5.5a4.7 4.7 0 0 1-2.04 3.08v2.56h3.3c1.94-1.79 3.04-4.42 3.04-7.39Z"/>
+                <path fill="#34A853" d="M12 22c2.75 0 5.06-.91 6.75-2.47l-3.3-2.56c-.91.61-2.08.97-3.45.97-2.65 0-4.89-1.79-5.69-4.2H2.9v2.64A10 10 0 0 0 12 22Z"/>
+                <path fill="#FBBC05" d="M6.31 13.74A5.98 5.98 0 0 1 6 12c0-.6.11-1.18.31-1.74V7.62H2.9A10 10 0 0 0 2 12c0 1.61.38 3.13 1.05 4.38l3.26-2.64Z"/>
+                <path fill="#EA4335" d="M12 5.98c1.49 0 2.82.51 3.87 1.5l2.9-2.9C17.05 2.98 14.75 2 12 2A10 10 0 0 0 2.9 7.62l3.41 2.64c.8-2.41 3.04-4.28 5.69-4.28Z"/>
+              </svg>
+              <span>Continue with Google</span>
+            <% end %>
+          <% end %>
+
+          <% if ENV['GITHUB_CLIENT_ID'].present? %>
+            <%= button_to user_github_omniauth_authorize_path,
+                method: :post,
+                class: "flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-cream-300 bg-white px-4 py-2.5 text-sm font-medium text-ink-800 transition-all duration-150 hover:bg-cream-100 hover:-translate-y-px active:translate-y-0" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 fill-ink-900">
+                <path d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.41-4.04-1.41-.55-1.38-1.33-1.74-1.33-1.74-1.09-.74.08-.72.08-.72 1.2.09 1.84 1.24 1.84 1.24 1.08 1.84 2.82 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.48-1.33-5.48-5.92 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.4 11.4 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.67 1.66.25 2.88.13 3.18.77.84 1.23 1.91 1.23 3.22 0 4.6-2.82 5.61-5.5 5.91.43.38.82 1.1.82 2.22v3.29c0 .32.21.7.83.58A12 12 0 0 0 12 .5Z"/>
+              </svg>
+              <span>Continue with GitHub</span>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="my-5 flex items-center gap-3">
+          <div class="h-px flex-1 bg-cream-300"></div>
+          <span class="text-xs text-ink-400">or</span>
+          <div class="h-px flex-1 bg-cream-300"></div>
+        </div>
+      <% end %>
+
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <div class="space-y-4">
+          <div>
+            <%= f.label :email, class: "mb-1 block text-sm font-medium text-ink-700" %>
+            <%= f.email_field :email,
+                autofocus: true,
+                autocomplete: "email",
+                class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber" %>
+          </div>
+
+          <div>
+            <%= f.label :password, class: "mb-1 block text-sm font-medium text-ink-700" %>
+            <%= f.password_field :password,
+                autocomplete: "new-password",
+                class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber" %>
+            <p class="mt-1 text-xs text-ink-400">At least 6 characters.</p>
+          </div>
+
+          <div>
+            <%= f.label :password_confirmation, "Confirm password", class: "mb-1 block text-sm font-medium text-ink-700" %>
+            <%= f.password_field :password_confirmation,
+                autocomplete: "new-password",
+                class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber" %>
+          </div>
+
+          <%= f.submit "Create account",
+              class: "mt-1 w-full cursor-pointer rounded-lg bg-amber py-2.5 text-sm font-medium text-ink-900 transition-all duration-200 hover:bg-amber-light" %>
+        </div>
+      <% end %>
+
+    </div>
+
+    <p class="mt-5 text-center text-sm text-ink-500">
+      Already have an account?
+      <%= link_to "Sign in", new_user_session_path,
+          class: "font-medium text-ink-800 underline underline-offset-2 transition-colors hover:text-amber" %>
+    </p>
 
   </div>
-
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,65 +1,88 @@
-<div class="mx-auto max-w-md">
+<div class="flex min-h-[70vh] items-center justify-center">
+  <div class="w-full max-w-sm animate-slide-up">
 
-  <h1 class="text-2xl font-semibold mb-6">
-    Sign in
-  </h1>
-
-  <div class="rounded-lg border bg-white p-6 shadow-sm">
-
-<div class="mb-6 space-y-3">
-  <%= button_to user_google_oauth2_omniauth_authorize_path,
-      method: :post,
-      class: "flex w-full items-center justify-center gap-3 rounded-md bg-black px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-zinc-800 hover:-translate-y-0.5 cursor-pointer active:translate-y-0" do %>
-    <span aria-hidden="true">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 fill-white">
-        <path d="M21.8 12.23c0-.68-.06-1.33-.17-1.96H12v3.71h5.5a4.7 4.7 0 0 1-2.04 3.08v2.56h3.3c1.94-1.79 3.04-4.42 3.04-7.39Z"/>
-        <path d="M12 22c2.75 0 5.06-.91 6.75-2.47l-3.3-2.56c-.91.61-2.08.97-3.45.97-2.65 0-4.89-1.79-5.69-4.2H2.9v2.64A10 10 0 0 0 12 22Z"/>
-        <path d="M6.31 13.74A5.98 5.98 0 0 1 6 12c0-.6.11-1.18.31-1.74V7.62H2.9A10 10 0 0 0 2 12c0 1.61.38 3.13 1.05 4.38l3.26-2.64Z"/>
-        <path d="M12 5.98c1.49 0 2.82.51 3.87 1.5l2.9-2.9C17.05 2.98 14.75 2 12 2A10 10 0 0 0 2.9 7.62l3.41 2.64c.8-2.41 3.04-4.28 5.69-4.28Z"/>
-      </svg>
-    </span>
-    <span>Continue with Google</span>
-  <% end %>
-
-  <%= button_to user_github_omniauth_authorize_path,
-      method: :post,
-      class: "flex w-full items-center justify-center gap-3 rounded-md bg-black px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-zinc-800 cursor-pointer hover:-translate-y-0.5 active:translate-y-0" do %>
-    <span aria-hidden="true">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 fill-white">
-        <path d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.41-4.04-1.41-.55-1.38-1.33-1.74-1.33-1.74-1.09-.74.08-.72.08-.72 1.2.09 1.84 1.24 1.84 1.24 1.08 1.84 2.82 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.48-1.33-5.48-5.92 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.4 11.4 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.67 1.66.25 2.88.13 3.18.77.84 1.23 1.91 1.23 3.22 0 4.6-2.82 5.61-5.5 5.91.43.38.82 1.1.82 2.22v3.29c0 .32.21.7.83.58A12 12 0 0 0 12 .5Z"/>
-      </svg>
-    </span>
-    <span>Continue with GitHub</span>
-  <% end %>
-</div>
-
-    <%= form_for(resource,
-        as: resource_name,
-        url: session_path(resource_name)) do |f| %>
-
-      <div class="space-y-4">
-
-        <div>
-          <%= f.label :email, class: "block text-sm font-medium" %>
-          <%= f.email_field :email,
-              class: "mt-1 w-full rounded-md border px-3 py-2" %>
-        </div>
-
-        <div>
-          <%= f.label :password, class: "block text-sm font-medium" %>
-          <%= f.password_field :password,
-              class: "mt-1 w-full rounded-md border px-3 py-2" %>
-        </div>
-
-        <div>
-          <%= f.submit "Sign in",
-              class: "w-full rounded-md bg-black px-4 py-2 text-white" %>
-        </div>
-
+    <div class="mb-8 text-center">
+      <div class="mb-3 flex items-center justify-center gap-2">
+        <span class="h-2.5 w-2.5 rounded-full bg-amber"></span>
+        <span class="font-display text-2xl font-light text-ink-900">Weekbook</span>
       </div>
+      <h1 class="font-display text-3xl font-light text-ink-900">Welcome back</h1>
+      <p class="mt-1 text-sm text-ink-500">Sign in to continue your story.</p>
+    </div>
 
-    <% end %>
+    <div class="rounded-xl border border-cream-300 bg-white p-6 shadow-warm">
+
+      <% oauth_available = ENV['GOOGLE_CLIENT_ID'].present? || ENV['GITHUB_CLIENT_ID'].present? %>
+
+      <% if oauth_available %>
+        <div class="space-y-2.5">
+          <% if ENV['GOOGLE_CLIENT_ID'].present? %>
+            <%= button_to user_google_oauth2_omniauth_authorize_path,
+                method: :post,
+                class: "flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-cream-300 bg-white px-4 py-2.5 text-sm font-medium text-ink-800 transition-all duration-150 hover:bg-cream-100 hover:-translate-y-px active:translate-y-0" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4">
+                <path fill="#4285F4" d="M21.8 12.23c0-.68-.06-1.33-.17-1.96H12v3.71h5.5a4.7 4.7 0 0 1-2.04 3.08v2.56h3.3c1.94-1.79 3.04-4.42 3.04-7.39Z"/>
+                <path fill="#34A853" d="M12 22c2.75 0 5.06-.91 6.75-2.47l-3.3-2.56c-.91.61-2.08.97-3.45.97-2.65 0-4.89-1.79-5.69-4.2H2.9v2.64A10 10 0 0 0 12 22Z"/>
+                <path fill="#FBBC05" d="M6.31 13.74A5.98 5.98 0 0 1 6 12c0-.6.11-1.18.31-1.74V7.62H2.9A10 10 0 0 0 2 12c0 1.61.38 3.13 1.05 4.38l3.26-2.64Z"/>
+                <path fill="#EA4335" d="M12 5.98c1.49 0 2.82.51 3.87 1.5l2.9-2.9C17.05 2.98 14.75 2 12 2A10 10 0 0 0 2.9 7.62l3.41 2.64c.8-2.41 3.04-4.28 5.69-4.28Z"/>
+              </svg>
+              <span>Continue with Google</span>
+            <% end %>
+          <% end %>
+
+          <% if ENV['GITHUB_CLIENT_ID'].present? %>
+            <%= button_to user_github_omniauth_authorize_path,
+                method: :post,
+                class: "flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-cream-300 bg-white px-4 py-2.5 text-sm font-medium text-ink-800 transition-all duration-150 hover:bg-cream-100 hover:-translate-y-px active:translate-y-0" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 fill-ink-900">
+                <path d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.41-4.04-1.41-.55-1.38-1.33-1.74-1.33-1.74-1.09-.74.08-.72.08-.72 1.2.09 1.84 1.24 1.84 1.24 1.08 1.84 2.82 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.48-1.33-5.48-5.92 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.4 11.4 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.67 1.66.25 2.88.13 3.18.77.84 1.23 1.91 1.23 3.22 0 4.6-2.82 5.61-5.5 5.91.43.38.82 1.1.82 2.22v3.29c0 .32.21.7.83.58A12 12 0 0 0 12 .5Z"/>
+              </svg>
+              <span>Continue with GitHub</span>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="my-5 flex items-center gap-3">
+          <div class="h-px flex-1 bg-cream-300"></div>
+          <span class="text-xs text-ink-400">or</span>
+          <div class="h-px flex-1 bg-cream-300"></div>
+        </div>
+      <% end %>
+
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <div class="space-y-4">
+          <div>
+            <%= f.label :email, class: "mb-1 block text-sm font-medium text-ink-700" %>
+            <%= f.email_field :email,
+                autofocus: true,
+                autocomplete: "email",
+                class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber" %>
+          </div>
+
+          <div>
+            <%= f.label :password, class: "mb-1 block text-sm font-medium text-ink-700" %>
+            <%= f.password_field :password,
+                autocomplete: "current-password",
+                class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber" %>
+          </div>
+
+          <%= f.submit "Sign in",
+              class: "mt-1 w-full cursor-pointer rounded-lg bg-ink-900 py-2.5 text-sm font-medium text-white transition-all duration-200 hover:bg-ink-700" %>
+        </div>
+      <% end %>
+
+    </div>
+
+    <p class="mt-5 text-center text-sm text-ink-500">
+      No account?
+      <%= link_to "Get started", new_user_registration_path,
+          class: "font-medium text-ink-800 underline underline-offset-2 transition-colors hover:text-amber" %>
+    </p>
+
+    <p class="mt-2 text-center text-sm">
+      <%= link_to "Forgot password?", new_user_password_path,
+          class: "text-ink-400 transition-colors hover:text-ink-600" %>
+    </p>
 
   </div>
-
 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,13 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-temporary>
-    <h2>
+  <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3" data-turbo-temporary>
+    <p class="text-sm font-medium text-red-700">
       <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
+            count: resource.errors.count,
+            resource: resource.class.model_name.human.downcase) %>
+    </p>
+    <ul class="mt-1 space-y-0.5 text-sm text-red-600">
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li>· <%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,42 +1,82 @@
 <% if user_signed_in? %>
-  <section class="space-y-4">
-    <h1 class="text-3xl font-semibold tracking-tight">Welcome back</h1>
-    <p class="text-zinc-600">
-      Your weekly recaps and private entries will live here soon.
-    </p>
 
-    <% if current_user.username.present? %>
-      <%= link_to "View profile", user_profile_path(current_user.username), class: "inline-block rounded-md bg-black px-4 py-2 text-sm text-white" %>
-    <% else %>
-      <%= link_to "Complete your profile", edit_profile_path, class: "inline-block rounded-md bg-black px-4 py-2 text-sm text-white" %>
-    <% end %>
-  </section>
-<% else %>
-
-  <section class="max-w-xl space-y-5">
-
-    <h1 class="text-4xl font-semibold tracking-tight">
-      Weekbook
-    </h1>
-
-    <p class="text-lg text-zinc-600">
-      Capture your week through small reflections.
-      Weekbook turns quick prompts throughout the week
-      into a meaningful weekly recap.
-    </p>
-
-    <div class="flex gap-3 pt-3">
-
-      <%= link_to "Create account",
-          new_user_registration_path,
-          class: "rounded-md bg-black px-4 py-2 text-white text-sm" %>
-
-      <%= link_to "Sign in",
-          new_user_session_path,
-          class: "rounded-md border border-zinc-300 px-4 py-2 text-sm" %>
-
+  <section class="space-y-8 animate-slide-up">
+    <div class="space-y-1">
+      <p class="text-sm font-medium text-amber">
+        Week <%= Date.today.cweek %> · <%= Date.today.beginning_of_week(:monday).strftime("%b %-d") %> – <%= Date.today.end_of_week(:monday).strftime("%b %-d") %>
+      </p>
+      <h1 class="font-display text-4xl font-light text-ink-900">
+        Welcome back<% if current_user.name_for_display.present? %>, <%= current_user.name_for_display.split.first %><% end %>.
+      </h1>
     </div>
 
+    <div class="grid gap-4 sm:grid-cols-2">
+      <div class="rounded-xl border border-cream-300 bg-white p-6 shadow-warm">
+        <p class="mb-1 text-xs font-medium uppercase tracking-widest text-ink-400">This week</p>
+        <p class="mb-4 text-ink-600">Your entries and weekly recap will live here.</p>
+        <% if current_user.username.present? %>
+          <%= link_to "View profile →", user_profile_path(current_user.username),
+              class: "text-sm font-medium text-amber transition-colors hover:text-amber-dark" %>
+        <% else %>
+          <%= link_to "Complete your profile →", edit_profile_path,
+              class: "text-sm font-medium text-amber transition-colors hover:text-amber-dark" %>
+        <% end %>
+      </div>
+
+      <div class="rounded-xl border border-dashed border-cream-400 bg-cream-100 p-6">
+        <p class="mb-1 text-xs font-medium uppercase tracking-widest text-ink-400">Coming soon</p>
+        <p class="text-ink-500">Prompts, entries, and AI-generated weekly digests.</p>
+      </div>
+    </div>
   </section>
+
+<% else %>
+
+  <div class="flex min-h-[70vh] flex-col justify-center">
+    <section class="max-w-2xl space-y-8 animate-slide-up">
+
+      <div class="space-y-4">
+        <h1 class="font-display text-5xl font-light leading-tight tracking-tight text-ink-900 sm:text-6xl">
+          Your week,<br>
+          <em class="font-light not-italic text-amber">told as story.</em>
+        </h1>
+        <p class="max-w-lg text-lg font-light leading-relaxed text-ink-500">
+          Small moments, captured throughout the week.
+          Synthesized into a narrative worth keeping.
+        </p>
+      </div>
+
+      <div class="flex flex-wrap gap-3">
+        <%= link_to "Get started",
+            new_user_registration_path,
+            class: "rounded-md bg-amber px-5 py-2.5 font-medium text-ink-900 transition-all duration-200 hover:bg-amber-light hover:-translate-y-px active:translate-y-0 shadow-warm" %>
+
+        <%= link_to "Sign in",
+            new_user_session_path,
+            class: "rounded-md border border-cream-400 bg-white px-5 py-2.5 font-medium text-ink-700 transition-all duration-200 hover:border-cream-400 hover:bg-cream-100" %>
+      </div>
+
+    </section>
+
+    <section class="mt-16 grid gap-4 sm:grid-cols-3 animate-fade-in">
+      <div class="rounded-xl border border-cream-300 bg-white p-5 shadow-warm">
+        <p class="mb-2 font-display text-2xl font-light text-ink-900">01</p>
+        <p class="mb-1 text-sm font-medium text-ink-800">Low-friction capture</p>
+        <p class="text-sm text-ink-500">Answer short prompts. Reply to a text. Takes ten seconds.</p>
+      </div>
+
+      <div class="rounded-xl border border-cream-300 bg-white p-5 shadow-warm">
+        <p class="mb-2 font-display text-2xl font-light text-amber">02</p>
+        <p class="mb-1 text-sm font-medium text-ink-800">Weekly narrative</p>
+        <p class="text-sm text-ink-500">Your entries become a cohesive story of your week.</p>
+      </div>
+
+      <div class="rounded-xl border border-cream-300 bg-white p-5 shadow-warm">
+        <p class="mb-2 font-display text-2xl font-light text-ink-900">03</p>
+        <p class="mb-1 text-sm font-medium text-ink-800">Share lightly</p>
+        <p class="text-sm text-ink-500">Publish to followers, or keep it private. You choose.</p>
+      </div>
+    </section>
+  </div>
 
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,50 +1,72 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Weekbook</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="min-h-screen bg-zinc-50 text-zinc-900">
+  <body class="min-h-screen bg-cream-200 text-ink-800 font-sans">
 
-  <nav class="border-b bg-white">
-    <div class="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-      <%= link_to "Weekbook", root_path, class: "font-semibold text-lg tracking-tight" %>
+    <nav class="sticky top-0 z-50 border-b border-white/5 bg-ink-900">
+      <div class="mx-auto flex max-w-5xl items-center justify-between px-4 py-3.5">
 
-      <div class="flex items-center gap-4 text-sm">
-        <% if user_signed_in? %>
-  <% if current_user.username.present? %>
-    <%= link_to "Profile", user_profile_path(current_user.username), class: "hover:underline" %>
-  <% else %>
-    <%= link_to "Complete profile", edit_profile_path, class: "hover:underline" %>
-  <% end %>
-
-  <%= link_to "Sign out",
-      destroy_user_session_path,
-      data: { turbo_method: :delete },
-      class: "text-zinc-600 hover:text-black" %>
-<% else %>
-          <%= link_to "Sign in",
-              new_user_session_path,
-              class: "text-zinc-600 hover:text-black" %>
-
-          <%= link_to "Sign up",
-              new_user_registration_path,
-              class: "rounded-md bg-black px-3 py-1.5 text-white" %>
+        <%= link_to root_path, class: "group flex items-center gap-2" do %>
+          <span class="h-2 w-2 rounded-full bg-amber transition-all duration-300 group-hover:scale-125"></span>
+          <span class="font-display text-xl font-light tracking-tight text-white">Weekbook</span>
         <% end %>
+
+        <div class="flex items-center gap-5 text-sm">
+          <% if user_signed_in? %>
+            <% if current_user.username.present? %>
+              <%= link_to "Profile", user_profile_path(current_user.username),
+                  class: "text-ink-300 transition-colors duration-200 hover:text-white" %>
+            <% else %>
+              <%= link_to "Complete profile", edit_profile_path,
+                  class: "text-ink-300 transition-colors duration-200 hover:text-white" %>
+            <% end %>
+
+            <%= link_to "Sign out",
+                destroy_user_session_path,
+                data: { turbo_method: :delete },
+                class: "text-ink-500 transition-colors duration-200 hover:text-ink-300" %>
+          <% else %>
+            <%= link_to "Sign in",
+                new_user_session_path,
+                class: "text-ink-300 transition-colors duration-200 hover:text-white" %>
+
+            <%= link_to "Get started",
+                new_user_registration_path,
+                class: "rounded-md bg-amber px-3.5 py-1.5 font-medium text-ink-900 transition-all duration-200 hover:bg-amber-light hover:-translate-y-px active:translate-y-0" %>
+          <% end %>
+        </div>
       </div>
-    </div>
-  </nav>
+    </nav>
 
-  <main class="mx-auto max-w-5xl px-4 py-10">
-    <%= yield %>
-  </main>
+    <% if notice.present? %>
+      <div class="border-b border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-800" data-turbo-temporary>
+        <div class="mx-auto max-w-5xl"><%= notice %></div>
+      </div>
+    <% end %>
 
-</body>
+    <% if alert.present? %>
+      <div class="border-b border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700" data-turbo-temporary>
+        <div class="mx-auto max-w-5xl"><%= alert %></div>
+      </div>
+    <% end %>
+
+    <main class="mx-auto max-w-5xl px-4 py-10">
+      <%= yield %>
+    </main>
+
+  </body>
 </html>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,77 +1,86 @@
-<div class="mx-auto max-w-2xl px-4 py-10">
-  <div class="rounded-2xl border bg-white p-6 shadow-sm">
-    <h1 class="text-2xl font-bold text-gray-900">Edit profile</h1>
-    <p class="mt-2 text-sm text-gray-600">
-      Set up your public identity for Weekbook.
-    </p>
+<div class="mx-auto max-w-lg animate-slide-up">
+
+  <div class="mb-6">
+    <h1 class="font-display text-3xl font-light text-ink-900">Edit profile</h1>
+    <p class="mt-1 text-sm text-ink-500">Your public identity on Weekbook.</p>
+  </div>
+
+  <div class="rounded-xl border border-cream-300 bg-white p-6 shadow-warm">
 
     <%= form_with model: @user, url: profile_path, method: :patch,
-                  class: "mt-6 space-y-5",
+                  class: "space-y-5",
                   html: { multipart: true } do |f| %>
+
       <% if @user.errors.any? %>
-        <div class="rounded-lg border border-red-200 bg-red-50 p-4">
-          <h2 class="font-semibold text-red-800">
-            Please fix the following:
-          </h2>
-          <ul class="mt-2 list-disc pl-5 text-sm text-red-700">
+        <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+          <p class="text-sm font-medium text-red-700">Please fix the following:</p>
+          <ul class="mt-1 space-y-0.5 text-sm text-red-600">
             <% @user.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
+              <li>· <%= message %></li>
             <% end %>
           </ul>
         </div>
       <% end %>
 
-      <div class="space-y-3">
-        <%= f.label :avatar, class: "block text-sm font-medium text-gray-700" %>
-
+      <%# Avatar %>
+      <div>
+        <%= f.label :avatar, "Photo", class: "mb-2 block text-sm font-medium text-ink-700" %>
         <div class="flex items-center gap-4">
           <% if @user.avatar.attached? %>
             <%= image_tag @user.avatar,
-                class: "h-20 w-20 rounded-full border object-cover" %>
+                class: "h-16 w-16 rounded-full border-2 border-cream-300 object-cover" %>
           <% else %>
-            <div class="flex h-20 w-20 items-center justify-center rounded-full bg-gray-200 text-sm text-gray-500">
-              avatar
+            <div class="flex h-16 w-16 items-center justify-center rounded-full bg-cream-200 font-display text-xl font-light text-ink-400">
+              <%= @user.name_for_display[0]&.upcase %>
             </div>
           <% end %>
 
-          <label class="cursor-pointer rounded-md border px-4 py-2 text-sm hover:bg-gray-50">
-            Change avatar
-            <%= f.file_field :avatar,
-                accept: "image/*",
-                class: "hidden" %>
+          <label class="cursor-pointer rounded-md border border-cream-400 bg-cream-50 px-4 py-2 text-sm font-medium text-ink-700 transition-all hover:bg-cream-200">
+            Change photo
+            <%= f.file_field :avatar, accept: "image/*", class: "hidden" %>
           </label>
         </div>
       </div>
 
+      <%# Username %>
       <div>
-        <%= f.label :username, class: "mb-1 block text-sm font-medium text-gray-700" %>
-        <%= f.text_field :username,
-            class: "w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-gray-900 focus:outline-none",
-            placeholder: "omer" %>
-        <p class="mt-1 text-xs text-gray-500">
-          Letters, numbers, and underscores only.
-        </p>
+        <%= f.label :username, class: "mb-1 block text-sm font-medium text-ink-700" %>
+        <div class="relative">
+          <span class="absolute inset-y-0 left-3 flex items-center text-ink-400 text-sm">@</span>
+          <%= f.text_field :username,
+              class: "w-full rounded-lg border border-cream-400 bg-white pl-7 pr-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber",
+              placeholder: "yourname" %>
+        </div>
+        <p class="mt-1 text-xs text-ink-400">Letters, numbers, and underscores only.</p>
       </div>
 
+      <%# Display name %>
       <div>
-        <%= f.label :display_name, class: "mb-1 block text-sm font-medium text-gray-700" %>
+        <%= f.label :display_name, "Display name", class: "mb-1 block text-sm font-medium text-ink-700" %>
         <%= f.text_field :display_name,
-            class: "w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-gray-900 focus:outline-none",
-            placeholder: "Omer Siddiqui" %>
+            class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber",
+            placeholder: "Your name" %>
       </div>
 
+      <%# Bio %>
       <div>
-        <%= f.label :bio, class: "mb-1 block text-sm font-medium text-gray-700" %>
+        <%= f.label :bio, class: "mb-1 block text-sm font-medium text-ink-700" %>
         <%= f.text_area :bio,
-            rows: 5,
-            class: "w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-gray-900 focus:outline-none",
+            rows: 4,
+            class: "w-full rounded-lg border border-cream-400 bg-white px-3 py-2.5 text-sm text-ink-800 placeholder-ink-300 transition-colors focus:border-amber focus:outline-none focus:ring-1 focus:ring-amber resize-none",
             placeholder: "A few words about yourself..." %>
+        <p class="mt-1 text-xs text-ink-400">Max 280 characters.</p>
       </div>
 
-      <div>
+      <div class="flex items-center gap-3 border-t border-cream-200 pt-4">
         <%= f.submit "Save profile",
-            class: "inline-flex rounded-lg bg-gray-900 px-4 py-2 text-white hover:bg-gray-800" %>
+            class: "cursor-pointer rounded-lg bg-ink-900 px-5 py-2.5 text-sm font-medium text-white transition-all duration-200 hover:bg-ink-700 hover:-translate-y-px active:translate-y-0" %>
+
+        <%= link_to "Cancel",
+            current_user.username.present? ? user_profile_path(current_user.username) : root_path,
+            class: "text-sm text-ink-500 transition-colors hover:text-ink-800" %>
       </div>
+
     <% end %>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,57 +1,82 @@
-<section class="max-w-2xl space-y-6">
-  <div class="rounded-xl border bg-white p-6 shadow-sm">
-    <div class="space-y-2">
-      <% if @user.avatar.attached? %>
-        <%= image_tag @user.avatar,
-            class: "mb-4 h-24 w-24 rounded-full border object-cover" %>
-      <% else %>
-        <div class="mb-4 h-24 w-24 rounded-full bg-zinc-200"></div>
-      <% end %>
+<div class="animate-slide-up">
+  <div class="grid gap-8 md:grid-cols-[280px_1fr]">
 
-      <p class="text-sm text-zinc-500">@<%= @user.username %></p>
+    <%# Profile card %>
+    <div class="space-y-4">
+      <div class="rounded-xl border border-cream-300 bg-white p-6 shadow-warm">
 
-      <h1 class="text-2xl font-semibold tracking-tight">
-        <%= @user.name_for_display %>
-      </h1>
+        <% if @user.avatar.attached? %>
+          <%= image_tag @user.avatar,
+              class: "mb-4 h-20 w-20 rounded-full border-2 border-cream-300 object-cover" %>
+        <% else %>
+          <div class="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-cream-200 text-2xl font-display font-light text-ink-400">
+            <%= @user.name_for_display[0]&.upcase %>
+          </div>
+        <% end %>
 
-      <% if @user.bio.present? %>
-        <p class="text-zinc-700"><%= @user.bio %></p>
-      <% else %>
-        <p class="text-zinc-500">No bio yet.</p>
-      <% end %>
+        <h1 class="font-display text-2xl font-light text-ink-900">
+          <%= @user.name_for_display %>
+        </h1>
 
-      <div class="flex gap-6 pt-2 text-sm text-zinc-600">
-        <p><span class="font-medium text-zinc-900"><%= @user.followers.count %></span> followers</p>
-        <p><span class="font-medium text-zinc-900"><%= @user.following.count %></span> following</p>
-      </div>
+        <% if @user.username.present? %>
+          <p class="mt-0.5 text-sm font-medium text-amber">@<%= @user.username %></p>
+        <% end %>
 
-      <% if user_signed_in? && current_user != @user %>
-        <div class="pt-4">
-          <% if current_user.following?(@user) %>
-            <%= button_to "Unfollow",
-                follow_user_path(@user.username),
-                method: :delete,
-                class: "rounded-md border border-zinc-300 px-4 py-2 text-sm hover:bg-zinc-100" %>
-          <% else %>
-            <%= button_to "Follow",
-                follow_user_path(@user.username),
-                method: :post,
-                class: "rounded-md bg-black px-4 py-2 text-sm text-white" %>
-          <% end %>
+        <% if @user.bio.present? %>
+          <p class="mt-3 text-sm leading-relaxed text-ink-600"><%= @user.bio %></p>
+        <% else %>
+          <p class="mt-3 text-sm text-ink-400 italic">No bio yet.</p>
+        <% end %>
+
+        <div class="mt-4 flex gap-5 border-t border-cream-200 pt-4 text-sm">
+          <div>
+            <span class="font-semibold text-ink-900"><%= @user.followers.count %></span>
+            <span class="ml-1 text-ink-500">followers</span>
+          </div>
+          <div>
+            <span class="font-semibold text-ink-900"><%= @user.following.count %></span>
+            <span class="ml-1 text-ink-500">following</span>
+          </div>
         </div>
-      <% end %>
+
+        <% if user_signed_in? && current_user != @user %>
+          <div class="mt-4">
+            <% if current_user.following?(@user) %>
+              <%= button_to "Unfollow",
+                  follow_user_path(@user.username),
+                  method: :delete,
+                  class: "w-full rounded-md border border-cream-400 bg-white px-4 py-2 text-sm font-medium text-ink-700 transition-all duration-200 hover:border-ink-300 hover:bg-cream-100" %>
+            <% else %>
+              <%= button_to "Follow",
+                  follow_user_path(@user.username),
+                  method: :post,
+                  class: "w-full rounded-md bg-ink-900 px-4 py-2 text-sm font-medium text-white transition-all duration-200 hover:bg-ink-700 hover:-translate-y-px active:translate-y-0" %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if user_signed_in? && current_user == @user %>
+          <div class="mt-4 border-t border-cream-200 pt-4">
+            <%= link_to "Edit profile",
+                edit_profile_path,
+                class: "text-sm text-ink-500 transition-colors hover:text-ink-800" %>
+          </div>
+        <% end %>
+
+      </div>
     </div>
 
-    <% if user_signed_in? && current_user == @user %>
-      <div class="mt-4">
-        <%= link_to "Edit profile",
-            edit_profile_path,
-            class: "text-sm text-zinc-600 hover:text-black hover:underline" %>
+    <%# Content area %>
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="font-display text-xl font-light text-ink-700">Weekly recaps</h2>
       </div>
-    <% end %>
-  </div>
 
-  <div class="rounded-xl border border-dashed bg-zinc-50 p-8 text-center text-zinc-500">
-    Weekly recaps will appear here soon.
+      <div class="rounded-xl border border-dashed border-cream-400 bg-cream-100 px-8 py-12 text-center">
+        <p class="font-display text-3xl font-light text-ink-300">—</p>
+        <p class="mt-2 text-sm text-ink-400">No recaps published yet.</p>
+      </div>
+    </div>
+
   </div>
-</section>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -314,13 +314,17 @@ Devise.setup do |config|
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
 
-  config.omniauth :google_oauth2,
-                  ENV.fetch('GOOGLE_CLIENT_ID'),
-                  ENV.fetch('GOOGLE_CLIENT_SECRET'),
-                  {}
+  if ENV['GOOGLE_CLIENT_ID'].present?
+    config.omniauth :google_oauth2,
+                    ENV['GOOGLE_CLIENT_ID'],
+                    ENV['GOOGLE_CLIENT_SECRET'],
+                    {}
+  end
 
-  config.omniauth :github,
-                  ENV.fetch('GITHUB_CLIENT_ID'),
-                  ENV.fetch('GITHUB_CLIENT_SECRET'),
-                  scope: 'user:email'
+  if ENV['GITHUB_CLIENT_ID'].present?
+    config.omniauth :github,
+                    ENV['GITHUB_CLIENT_ID'],
+                    ENV['GITHUB_CLIENT_SECRET'],
+                    scope: 'user:email'
+  end
 end


### PR DESCRIPTION
- Define custom Tailwind v4 theme via @theme: ink/cream/amber palette, Fraunces display + Inter sans font stack, slide-up/fade-in animations, warm shadow tokens, amber selection highlight
- Dark ink-900 navbar with amber dot logo mark, flash message display (notice/alert) added to layout — previously missing
- Redesigned landing page: Fraunces hero headline, "told as story" amber italic, three-pillar feature cards with numbered Fraunces accents
- Redesigned auth pages (sign in / sign up): centered card, brand mark at top, colorful real Google icon, conditional OAuth button rendering
- Redesigned profile: two-column layout with avatar initials fallback, amber @username, follower stats row, week recap placeholder
- Profile edit: @ prefix on username field, amber focus ring, cancel link
- Devise errors partial: styled with red-50 background
- Add fade_in_controller.js: IntersectionObserver-based reveal animation
- Make Devise OAuth config conditional on env vars so app boots without GOOGLE_CLIENT_ID/GITHUB_CLIENT_ID set in dev