### PR TITLE
feat: Prompt system — PromptTemplate + PromptDispatch with 22 seed pr…

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -8,11 +8,13 @@ class EntriesController < ApplicationController
     @week_start = Date.current.beginning_of_week(:monday)
     @entries = current_user.entries.for_week(@week_start).recent
     @entry = Entry.new
+    @prompt = PromptDispatch.for_current_week(current_user)
   end
 
   def new
     @entry = Entry.new
     @week_start = Date.current.beginning_of_week(:monday)
+    @prompt = PromptDispatch.for_current_week(current_user)
   end
 
   def create

--- a/app/controllers/prompt_dispatches_controller.rb
+++ b/app/controllers/prompt_dispatches_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PromptDispatchesController < ApplicationController
+  before_action :authenticate_user!
+
+  def skip
+    dispatch = current_user.prompt_dispatches.find(params[:id])
+    dispatch.skip!
+    respond_to do |format|
+      format.html { redirect_to entries_path }
+      format.turbo_stream { render turbo_stream: turbo_stream.replace('prompt_banner', '') }
+    end
+  end
+end

--- a/app/models/prompt_dispatch.rb
+++ b/app/models/prompt_dispatch.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class PromptDispatch < ApplicationRecord
+  belongs_to :user
+  belongs_to :prompt_template
+
+  STATUSES = %w[pending responded skipped].freeze
+
+  validates :status, inclusion: { in: STATUSES }
+  validates :dispatched_at, presence: true
+  validates :week_start_date, presence: true
+  validates :user_id, uniqueness: { scope: :week_start_date, message: 'already has a prompt for this week' }
+
+  scope :for_week, ->(date) { where(week_start_date: date.beginning_of_week(:monday)) }
+  scope :pending, -> { where(status: 'pending') }
+
+  def self.for_current_week(user)
+    monday = Date.current.beginning_of_week(:monday)
+    find_or_create_for_week(user, monday)
+  end
+
+  def self.find_or_create_for_week(user, monday)
+    existing = find_by(user: user, week_start_date: monday)
+    return existing if existing
+
+    template = PromptTemplate.random_for_week
+    return nil unless template
+
+    create!(
+      user: user,
+      prompt_template: template,
+      dispatched_at: Time.current,
+      week_start_date: monday
+    )
+  end
+
+  def pending?
+    status == 'pending'
+  end
+
+  def respond!
+    update!(status: 'responded')
+  end
+
+  def skip!
+    update!(status: 'skipped')
+  end
+end

--- a/app/models/prompt_template.rb
+++ b/app/models/prompt_template.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PromptTemplate < ApplicationRecord
+  CATEGORIES = %w[reflection gratitude challenge highlight].freeze
+
+  has_many :prompt_dispatches, dependent: :destroy
+
+  validates :body, presence: true
+  validates :category, inclusion: { in: CATEGORIES }
+
+  scope :active, -> { where(active: true) }
+  scope :for_category, ->(cat) { where(category: cat) }
+
+  def self.random_for_week
+    active.order('RANDOM()').first
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
   has_many :identities, dependent: :destroy
   has_many :weekly_digests, dependent: :destroy
   has_many :entries, dependent: :destroy
+  has_many :prompt_dispatches, dependent: :destroy
 
   has_one_attached :avatar
 

--- a/app/views/entries/_prompt.html.erb
+++ b/app/views/entries/_prompt.html.erb
@@ -1,0 +1,17 @@
+<% if prompt&.prompt_template %>
+  <turbo-frame id="prompt_banner">
+    <div class="mb-5 flex items-start gap-3 rounded-xl border border-amber/20 bg-amber/5 px-4 py-3.5">
+      <span class="mt-0.5 text-amber">✦</span>
+      <div class="flex-1">
+        <p class="text-xs font-medium uppercase tracking-widest text-amber/80"><%= prompt.prompt_template.category.capitalize %></p>
+        <p class="mt-0.5 text-sm text-ink-700"><%= prompt.prompt_template.body %></p>
+      </div>
+      <% if prompt.pending? %>
+        <%= button_to skip_prompt_dispatch_path(prompt), method: :patch,
+            class: "text-xs text-ink-300 hover:text-ink-500 transition-colors cursor-pointer mt-0.5" do %>
+          Dismiss
+        <% end %>
+      <% end %>
+    </div>
+  </turbo-frame>
+<% end %>

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -8,6 +8,8 @@
     </p>
   </div>
 
+  <%= render 'prompt', prompt: @prompt %>
+
   <%# Quick-add form %>
   <div class="mb-8 rounded-xl border border-cream-300 bg-white p-5 shadow-warm">
     <%= form_with model: @entry, url: entries_path, data: { controller: "char-count", turbo_frame: "_top" } do |f| %>

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -7,6 +7,8 @@
       <p class="mt-1 text-sm text-ink-500"><%= Date.current.strftime('%A, %B %-d') %></p>
     </div>
 
+    <%= render 'prompt', prompt: @prompt %>
+
     <%= form_with model: @entry, url: entries_path do |f| %>
       <%= f.text_area :content,
           autofocus: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,10 @@ Rails.application.routes.draw do
   end
 
   resources :entries, only: %i[index new create destroy]
+
+  resources :prompt_dispatches, only: [] do
+    member do
+      patch :skip
+    end
+  end
 end

--- a/db/migrate/20260327081907_create_prompt_templates.rb
+++ b/db/migrate/20260327081907_create_prompt_templates.rb
@@ -1,0 +1,12 @@
+class CreatePromptTemplates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :prompt_templates do |t|
+      t.text :body, null: false
+      t.string :category, null: false
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+    add_index :prompt_templates, [:category, :active]
+  end
+end

--- a/db/migrate/20260327081908_create_prompt_dispatches.rb
+++ b/db/migrate/20260327081908_create_prompt_dispatches.rb
@@ -1,0 +1,14 @@
+class CreatePromptDispatches < ActiveRecord::Migration[7.1]
+  def change
+    create_table :prompt_dispatches do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :prompt_template, null: false, foreign_key: true
+      t.datetime :dispatched_at, null: false
+      t.string :status, null: false, default: 'pending'
+      t.date :week_start_date, null: false
+
+      t.timestamps
+    end
+    add_index :prompt_dispatches, [:user_id, :week_start_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_27_081417) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_27_081908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,28 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_27_081417) do
     t.index ["user_id"], name: "index_identities_on_user_id"
   end
 
+  create_table "prompt_dispatches", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "prompt_template_id", null: false
+    t.datetime "dispatched_at", null: false
+    t.string "status", default: "pending", null: false
+    t.date "week_start_date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prompt_template_id"], name: "index_prompt_dispatches_on_prompt_template_id"
+    t.index ["user_id", "week_start_date"], name: "index_prompt_dispatches_on_user_id_and_week_start_date", unique: true
+    t.index ["user_id"], name: "index_prompt_dispatches_on_user_id"
+  end
+
+  create_table "prompt_templates", force: :cascade do |t|
+    t.text "body", null: false
+    t.string "category", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category", "active"], name: "index_prompt_templates_on_category_and_active"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -111,5 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_27_081417) do
   add_foreign_key "follows", "users", column: "followed_id"
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "identities", "users"
+  add_foreign_key "prompt_dispatches", "prompt_templates"
+  add_foreign_key "prompt_dispatches", "users"
   add_foreign_key "weekly_digests", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,44 @@
 # frozen_string_literal: true
 
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Idempotent: only creates prompts that don't already exist (matched by body)
+
+prompts = [
+  # Reflection
+  { category: 'reflection', body: 'What surprised you most this week?' },
+  { category: 'reflection', body: 'What decision are you still thinking about?' },
+  { category: 'reflection', body: 'What did this week teach you about yourself?' },
+  { category: 'reflection', body: 'What would you do differently if you could rewind the week?' },
+  { category: 'reflection', body: 'What conversation is still replaying in your head?' },
+  { category: 'reflection', body: 'What felt harder than expected? What felt easier?' },
+
+  # Gratitude
+  { category: 'gratitude', body: 'Who made your week better, even in a small way?' },
+  { category: 'gratitude', body: 'What ordinary moment are you glad you noticed?' },
+  { category: 'gratitude', body: 'What did you have access to this week that you usually take for granted?' },
+  { category: 'gratitude', body: 'What worked well — something you might forget to appreciate?' },
+  { category: 'gratitude', body: 'What made you smile this week?' },
+
+  # Challenge
+  { category: 'challenge', body: 'What felt stuck? What got you unstuck — or kept you there?' },
+  { category: 'challenge', body: 'Where did you push yourself outside your comfort zone?' },
+  { category: 'challenge', body: 'What drains you right now, and what might shift that?' },
+  { category: 'challenge', body: 'What is one thing you kept putting off, and what is actually stopping you?' },
+  { category: 'challenge', body: 'What tension or conflict showed up this week?' },
+
+  # Highlight
+  { category: 'highlight', body: "What was the best part of your week — the moment you'd want to remember?" },
+  { category: 'highlight', body: 'What did you make or ship this week, big or small?' },
+  { category: 'highlight', body: 'What moment felt most like you — most aligned with who you want to be?' },
+  { category: 'highlight', body: 'What did you learn this week that actually changed how you think?' },
+  { category: 'highlight', body: 'If you had to describe this week in one sentence, what would it be?' },
+  { category: 'highlight', body: 'What energized you this week?' }
+]
+
+prompts.each do |attrs|
+  PromptTemplate.find_or_create_by!(body: attrs[:body]) do |p|
+    p.category = attrs[:category]
+    p.active = true
+  end
+end
+
+puts "Seeded #{PromptTemplate.count} prompt templates."

--- a/spec/factories/prompt_dispatches.rb
+++ b/spec/factories/prompt_dispatches.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :prompt_dispatch do
+    association :user
+    association :prompt_template
+    dispatched_at { Time.current }
+    status { 'pending' }
+    week_start_date { Date.current.beginning_of_week(:monday) }
+
+    trait :responded do
+      status { 'responded' }
+    end
+
+    trait :skipped do
+      status { 'skipped' }
+    end
+  end
+end

--- a/spec/factories/prompt_templates.rb
+++ b/spec/factories/prompt_templates.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :prompt_template do
+    sequence(:body) { |n| "What was the highlight of your week? (#{n})" }
+    category { 'highlight' }
+    active { true }
+
+    trait :reflection do
+      category { 'reflection' }
+      body { 'What surprised you most this week?' }
+    end
+
+    trait :inactive do
+      active { false }
+    end
+  end
+end

--- a/spec/models/prompt_dispatch_spec.rb
+++ b/spec/models/prompt_dispatch_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PromptDispatch, type: :model do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      expect(build(:prompt_dispatch)).to be_valid
+    end
+
+    it 'prevents two dispatches for the same user and week' do
+      dispatch = create(:prompt_dispatch)
+      duplicate = build(:prompt_dispatch, user: dispatch.user, week_start_date: dispatch.week_start_date)
+      expect(duplicate).not_to be_valid
+    end
+
+    it 'allows different users to have dispatches for the same week' do
+      dispatch = create(:prompt_dispatch)
+      other = build(:prompt_dispatch, week_start_date: dispatch.week_start_date)
+      expect(other).to be_valid
+    end
+  end
+
+  describe '.for_current_week' do
+    let(:user) { create(:user) }
+
+    context 'when no dispatch exists for this week' do
+      it 'creates a new dispatch when templates are available' do
+        create(:prompt_template)
+        expect { PromptDispatch.for_current_week(user) }.to change(PromptDispatch, :count).by(1)
+      end
+
+      it 'returns nil when no active templates exist' do
+        expect(PromptDispatch.for_current_week(user)).to be_nil
+      end
+    end
+
+    context 'when a dispatch already exists for this week' do
+      it 'returns the existing dispatch without creating a new one' do
+        existing = create(:prompt_dispatch, user: user)
+        expect { PromptDispatch.for_current_week(user) }.not_to change(PromptDispatch, :count)
+        expect(PromptDispatch.for_current_week(user)).to eq(existing)
+      end
+    end
+  end
+
+  describe '#pending?' do
+    it 'returns true for pending status' do
+      expect(build(:prompt_dispatch, status: 'pending').pending?).to be true
+    end
+
+    it 'returns false for skipped status' do
+      expect(build(:prompt_dispatch, :skipped).pending?).to be false
+    end
+  end
+
+  describe '#skip!' do
+    it 'updates status to skipped' do
+      dispatch = create(:prompt_dispatch)
+      dispatch.skip!
+      expect(dispatch.reload.status).to eq('skipped')
+    end
+  end
+end

--- a/spec/models/prompt_template_spec.rb
+++ b/spec/models/prompt_template_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PromptTemplate, type: :model do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      expect(build(:prompt_template)).to be_valid
+    end
+
+    it 'requires body' do
+      expect(build(:prompt_template, body: '')).not_to be_valid
+    end
+
+    it 'requires a valid category' do
+      expect(build(:prompt_template, category: 'unknown')).not_to be_valid
+    end
+  end
+
+  describe '.random_for_week' do
+    it 'returns an active template' do
+      create(:prompt_template)
+      create(:prompt_template, :inactive)
+      result = PromptTemplate.random_for_week
+      expect(result).to be_active
+    end
+
+    it 'returns nil when no active templates exist' do
+      create(:prompt_template, :inactive)
+      expect(PromptTemplate.random_for_week).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
…ompts

- PromptTemplate: 4 categories (reflection, gratitude, challenge, highlight), active scope, random_for_week
- PromptDispatch: one per user per week (unique index), pending/responded/skipped status, auto-created on first entry page visit
- EntriesController: loads this week's prompt via PromptDispatch.for_current_week
- Prompt banner shown above entry form on index + new views; dismissible via Turbo Stream
- 22 seed prompts covering all 4 categories (db/seeds.rb, idempotent)
- 33 model specs passing