### PR TITLE
feat: AI digest generation (Phase 6)

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -9,6 +9,13 @@ class EntriesController < ApplicationController
     @entries = current_user.entries.for_week(@week_start).recent
     @entry = Entry.new
     @prompt = PromptDispatch.for_current_week(current_user)
+    if @entries.any?
+      @current_digest = current_user.weekly_digests.find_or_create_by(
+        week_start_date: @week_start,
+        week_number: @week_start.cweek,
+        year: @week_start.cwyear
+      )
+    end
   end
 
   def new

--- a/app/controllers/weekly_digests_controller.rb
+++ b/app/controllers/weekly_digests_controller.rb
@@ -2,8 +2,8 @@
 
 class WeeklyDigestsController < ApplicationController
   before_action :authenticate_user!, except: %i[show]
-  before_action :set_digest, only: %i[show edit update publish unpublish]
-  before_action :require_owner!, only: %i[edit update publish unpublish]
+  before_action :set_digest, only: %i[show edit update publish unpublish generate]
+  before_action :require_owner!, only: %i[edit update publish unpublish generate]
 
   def index
     @digests = current_user.weekly_digests.recent
@@ -54,6 +54,13 @@ class WeeklyDigestsController < ApplicationController
   def unpublish
     @digest.unpublish!
     redirect_to weekly_digest_path(@digest), notice: 'Digest moved back to draft.'
+  end
+
+  def generate
+    week_start_date = @digest.week_start_date
+    DigestSummarizerJob.perform_later(@digest.user_id, week_start_date.to_s)
+    redirect_to edit_weekly_digest_path(@digest),
+                notice: "Generating your digest — check back in about 15 seconds and refresh."
   end
 
   private

--- a/app/jobs/digest_summarizer_job.rb
+++ b/app/jobs/digest_summarizer_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DigestSummarizerJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id, week_start_date_str)
+    user = User.find_by(id: user_id)
+    return unless user
+
+    week_start = Date.parse(week_start_date_str)
+    entries = user.entries.for_week(week_start).to_a
+    return if entries.empty?
+
+    # Find the prompt dispatch for the week (if any) and get its prompt_template body
+    dispatch = PromptDispatch.for_week(week_start).find_by(user: user)
+    prompt_text = dispatch&.prompt_template&.body
+
+    narrative = OpenaiSummarizer.new(entries, prompt_text: prompt_text).call
+    return if narrative.nil?
+
+    digest = WeeklyDigest.for_week(week_start)
+    digest.user = user
+    digest.content = narrative
+    digest.summary_line = narrative.split(/\.\s+|\.$/).first.to_s.truncate(160)
+    digest.save
+  end
+end

--- a/app/services/openai_summarizer.rb
+++ b/app/services/openai_summarizer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class OpenaiSummarizer
+  SYSTEM_PROMPT = <<~PROMPT.strip
+    You are a gentle, reflective writer. Given a person's raw journal entries from this week,
+    write a warm, first-person narrative (2–3 paragraphs) that captures the texture of their week.
+    Avoid clichés. Be specific. Sound like a human, not a recap. Do not use bullet points or headers.
+    Write in plain prose only.
+  PROMPT
+
+  def initialize(entries, prompt_text: nil)
+    @entries = entries
+    @prompt_text = prompt_text
+  end
+
+  def call
+    return nil if @entries.empty?
+    return nil if ENV["OPENAI_API_KEY"].to_s.strip.empty?
+
+    client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
+
+    response = client.chat(
+      parameters: {
+        model: "gpt-4o",
+        temperature: 0.7,
+        max_tokens: 600,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: build_user_content }
+        ]
+      }
+    )
+
+    response.dig("choices", 0, "message", "content")&.strip
+  rescue StandardError => e
+    Rails.logger.error("[OpenaiSummarizer] Error: #{e.message}")
+    nil
+  end
+
+  private
+
+  def build_user_content
+    lines = []
+    lines << "Weekly prompt: #{@prompt_text}" if @prompt_text.to_s.present?
+    lines << "\nMy entries this week:\n"
+    @entries.each_with_index do |entry, i|
+      lines << "#{i + 1}. #{entry.content}"
+    end
+    lines.join("\n")
+  end
+end

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -42,11 +42,20 @@
     <% end %>
   </div>
 
-  <% if current_user.weekly_digests.where(week_start_date: @week_start).empty? %>
-    <div class="mt-10 rounded-xl border border-cream-200 bg-cream-50 px-6 py-5 text-center">
-      <p class="text-sm text-ink-500">Ready to wrap up the week?</p>
-      <%= link_to "Create this week's digest →", new_weekly_digest_path,
-          class: "mt-2 inline-block text-sm font-medium text-amber hover:text-amber-dark transition-colors" %>
+  <% if @current_digest&.persisted? %>
+    <div class="mt-10 rounded-xl border border-amber/30 bg-amber/5 px-6 py-5">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <p class="text-sm font-medium text-ink-700">
+            <%= pluralize(@entries.size, "entry") %> this week — ready to reflect?
+          </p>
+          <p class="mt-0.5 text-xs text-ink-400">AI will weave your entries into a short narrative digest.</p>
+        </div>
+        <%= button_to "Generate this week's digest →",
+            generate_weekly_digest_path(@current_digest),
+            method: :post,
+            class: "shrink-0 rounded-lg bg-amber px-4 py-2 text-xs font-medium text-ink-900 transition-all duration-150 hover:bg-amber-light" %>
+      </div>
     </div>
   <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,7 @@ module Weekbook
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     member do
       patch :publish
       patch :unpublish
+      post :generate
     end
   end
 

--- a/spec/jobs/digest_summarizer_job_spec.rb
+++ b/spec/jobs/digest_summarizer_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DigestSummarizerJob, type: :job do
+  let(:user) { create(:user) }
+  let(:week_start) { Date.current.beginning_of_week(:monday) }
+
+  describe '#perform' do
+    context 'when user is not found' do
+      it 'returns early without raising' do
+        expect { described_class.new.perform(-1, week_start.to_s) }.not_to raise_error
+      end
+
+      it 'does not create a digest' do
+        expect {
+          described_class.new.perform(-1, week_start.to_s)
+        }.not_to change(WeeklyDigest, :count)
+      end
+    end
+
+    context 'when user has no entries this week' do
+      it 'returns early without creating a digest' do
+        expect {
+          described_class.new.perform(user.id, week_start.to_s)
+        }.not_to change(WeeklyDigest, :count)
+      end
+    end
+
+    context 'when user has entries this week' do
+      let!(:entry) { create(:entry, user: user, week_start_date: week_start) }
+
+      context 'when OpenaiSummarizer returns a narrative' do
+        let(:narrative) { "It was a genuinely good week. The work felt meaningful and real." }
+
+        before do
+          allow_any_instance_of(OpenaiSummarizer).to receive(:call).and_return(narrative)
+        end
+
+        it 'creates or updates the digest with the narrative' do
+          described_class.new.perform(user.id, week_start.to_s)
+          digest = WeeklyDigest.find_by(user: user, week_start_date: week_start)
+          expect(digest).to be_present
+          expect(digest.content).to eq(narrative)
+        end
+
+        it 'sets summary_line to the first sentence truncated to 160 chars' do
+          described_class.new.perform(user.id, week_start.to_s)
+          digest = WeeklyDigest.find_by(user: user, week_start_date: week_start)
+          expect(digest.summary_line).to eq("It was a genuinely good week")
+        end
+      end
+
+      context 'when OpenaiSummarizer returns nil' do
+        before do
+          allow_any_instance_of(OpenaiSummarizer).to receive(:call).and_return(nil)
+        end
+
+        it 'does not create a digest' do
+          expect {
+            described_class.new.perform(user.id, week_start.to_s)
+          }.not_to change(WeeklyDigest, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/openai_summarizer_spec.rb
+++ b/spec/services/openai_summarizer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OpenaiSummarizer do
+  describe '#call' do
+    context 'when entries are empty' do
+      it 'returns nil' do
+        summarizer = described_class.new([])
+        expect(summarizer.call).to be_nil
+      end
+    end
+
+    context 'when OPENAI_API_KEY is not set' do
+      let(:user) { create(:user) }
+      let(:entry) { create(:entry, user: user) }
+
+      it 'returns nil' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("OPENAI_API_KEY").and_return(nil)
+        allow(ENV).to receive(:fetch).and_call_original
+        summarizer = described_class.new([entry])
+        expect(summarizer.call).to be_nil
+      end
+
+      it 'returns nil when key is blank string' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("OPENAI_API_KEY").and_return("   ")
+        allow(ENV).to receive(:fetch).and_call_original
+        summarizer = described_class.new([entry])
+        expect(summarizer.call).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **OpenaiSummarizer service** (`app/services/openai_summarizer.rb`): calls gpt-4o with a reflective-writer system prompt to weave weekly entries into a 2–3 paragraph first-person narrative. Gracefully returns `nil` if `OPENAI_API_KEY` is absent or the API errors.
- **DigestSummarizerJob** (`app/jobs/digest_summarizer_job.rb`): Sidekiq-backed ActiveJob. Finds the user's entries + optional weekly prompt, calls `OpenaiSummarizer`, then finds-or-creates the `WeeklyDigest` and saves the narrative + first-sentence summary_line (≤160 chars).
- **Sidekiq wiring**: `config.active_job.queue_adapter = :sidekiq` in `application.rb`; Redis URL configured via `REDIS_URL` env var (defaults to `redis://localhost:6379/0`).
- **`POST /weekly_digests/:id/generate`** route + controller action: finds the digest, enqueues `DigestSummarizerJob`, redirects to edit with a "check back in 15 seconds" notice.
- **Entries index Generate CTA**: amber card shown only when the user has entries this week, with entry count and a `button_to` pointing at `generate_weekly_digest_path`. Digest is persisted via `find_or_create_by` before the path helper runs.

## Env vars needed before this works in production

| Var | Purpose |
|---|---|
| `OPENAI_API_KEY` | OpenAI API key for gpt-4o summarization |
| `REDIS_URL` | Redis connection URL for Sidekiq (e.g. `redis://your-redis.render.com:6379/0`) |

**Render setup required:**
- Add a **Sidekiq worker service** pointing at `bundle exec sidekiq` alongside the web service.
- Provision a **Redis** instance and wire `REDIS_URL` to both the web and worker services.

## Test plan

- [ ] Set `OPENAI_API_KEY` and `REDIS_URL` locally; start Sidekiq (`bundle exec sidekiq`)
- [ ] Write at least one entry this week — amber "Generate this week's digest" card appears below entries
- [ ] Click the button — redirected to digest edit page with generating notice
- [ ] Wait ~15 seconds, refresh — digest `content` field should contain the AI narrative
- [ ] Delete `OPENAI_API_KEY` — button still works, job silently no-ops (no digest content written, no error raised)
- [ ] Run `bundle exec rspec spec/services/ spec/jobs/ spec/requests/weekly_digests_spec.rb` — 22 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)