### PR TITLE
fix: entries spec syntax error from apostrophe in single-quoted string

### DIFF
--- a/spec/requests/entries_spec.rb
+++ b/spec/requests/entries_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Entries', type: :request do
 
         it "shows today's prompt card" do
           get entries_path
-          expect(response.body).to include('today's prompt')
+          expect(response.body).to include("today's prompt")
           expect(response.body).to include('What made you smile today?')
         end
       end
@@ -30,7 +30,7 @@ RSpec.describe 'Entries', type: :request do
       context 'without a prompt dispatch for today' do
         it 'does not show the prompt card' do
           get entries_path
-          expect(response.body).not_to include('today's prompt')
+          expect(response.body).not_to include("today's prompt")
         end
       end
 


### PR DESCRIPTION
## Summary

- Fixes syntax error in `spec/requests/entries_spec.rb` introduced when correcting the HTML entity `today&#39;s prompt` → `today's prompt`
- Replacing the entity with a literal apostrophe inside single quotes (`'today's prompt'`) produced invalid Ruby syntax
- Fixed by switching to double-quoted strings (`"today's prompt"`)

## Root cause

`replace_all` on the HTML entity string didn't account for the surrounding single-quote delimiters in Ruby. A simple quoting oversight.

## Test plan
- [ ] RuboCop passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)